### PR TITLE
JSON types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
-# schemats
+# pg-to-ts
 
 This is a personal fork of [PYST/schemats][pyst-fork], which is a fork of [SweetIQ/schemats][orig-repo].
 
 Usage:
 
-    git clone https://github.com/danvk/schemats.git
-    cd schemats
-    npm install
-    npm run build
-
-    node bin/schemats.js generate -c postgresql://user:pass@host/db -o dbschema.ts
+    npm install pg-to-ts
+    pg-to-ts generate -c postgresql://user:pass@host/db -o dbschema.ts
 
 The resulting file looks like:
 
@@ -46,6 +42,102 @@ export const tables = {
 ```
 
 This gives you most of the types you need for static analysis and runtime.
+
+## Features
+
+### Comments
+
+If you set a Postgres comment on a table or column:
+
+```sql
+COMMENT ON TABLE product IS 'Table containing products';
+COMMENT ON COLUMN product.name IS 'Human-readable product name';
+```
+
+Then these come out as JSDoc comments in the schema:
+
+```ts
+/** Table containing products */
+export interface Product {
+  id: string;
+  /** Human-readable product name */
+  name: string;
+  description: string;
+  created_at: Date;
+}
+```
+
+The TypeScript language service will surface these when it's helpful.
+
+### Dates as strings
+
+node-postgres returns timestamp columns as JavaScript Date objects. This makes
+a lot of sense, but it can lead to problems if you try to serialize them as
+JSON, which converts them to strings. This means that the serialized and de-
+serialized table types will be different.
+
+By default `pg-to-ts` will put `Date` types in your schema file, but if you'd
+prefer strings, pass `--datesAsStrings`. Note that you'll be responsible for
+making sure that timestamps/dates really do come back as strings, not Date objects.
+See <https://github.com/brianc/node-pg-types> for details.
+
+### JSON types
+
+By default, Postgres `json` and `jsonb` columns will be typed as `unknown`.
+This is safe but not very precise, and it can make them cumbersome to work with.
+Oftentimes you know what the type should be.
+
+To tell `pg-to-ts` to use a specific TypeScript type for a `json` column, use
+a JSDoc `@type` annotation:
+
+```sql
+ALTER TABLE product ADD COLUMN metadata jsonb;
+COMMENT ON COLUMN product.metadata is 'Additional information @type {ProductMetadata}';
+```
+
+On its own, this simply acts as documentation. But if you also specify the
+`--jsonTypesFile` flag, these annotations get incorporated into the schema:
+
+    pg-to-ts generate ... --jsonTypesFile './db-types' -o dbschema.ts
+
+Then your `dbschema.ts` will look like:
+
+```ts
+import {ProductMetadata} from './db-types';
+
+interface Product {
+  id: string;
+  name: string;
+  description: string;
+  created_at: Date;
+  metadata: ProductMetadata | null;
+}
+```
+
+Presumably your `db-types.ts` file will either re-export this type from elsewhere:
+
+```ts
+export {ProductMetadata} from './path/to/this-type';
+```
+
+or define it itself:
+
+```ts
+export interface ProductMetadata {
+  year?: number;
+  designer?: string;
+  starRating?: number;
+}
+```
+
+## Development Quickstart
+
+    git clone https://github.com/danvk/schemats.git
+    cd schemats
+    npm install
+    npm run build
+
+    node bin/schemats.js generate -c postgresql://user:pass@host/db -o dbschema.ts
 
 See [SweetIQ/schemats][orig-repo] for the original README.
 

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/PSYT/schemats.git"
+    "url": "https://github.com/danvk/pg-to-ts.git"
   },
   "bugs": {
-    "url": "https://github.com/PSYT/schemats/issues"
+    "url": "https://github.com/danvk/pg-to-ts/issues"
   },
-  "author": "Mengxuan Xia <xiamx2004@gmail.com>",
+  "author": "Dan Vanderkam <danvdk@gmail.com>",
   "contributors": [
-    "Dan Vanderkam <danvdk@gmail.com>",
+    "Mengxuan Xia <xiamx2004@gmail.com>",
     "Arnaud Benhamdine <arnaud.benhamdine@gmail.com>",
     "zigomir <zigomir@gmail.com>",
     "Mark Crisp <macr1324@gmail.com>",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,8 @@ interface SchematsConfig {
     output: string,
     camelCase: boolean,
     noHeader: boolean,
-    datesAsStrings: boolean;
+    datesAsStrings: boolean,
+    jsonTypesFile: string,
 }
 
 let argv: SchematsConfig = yargs
@@ -58,6 +59,12 @@ let argv: SchematsConfig = yargs
         'See https://github.com/brianc/node-pg-types for details.'
     )
 
+    .describe(
+        'jsonTypesFile',
+        'If a JSON column has an @type jsdoc tag in its comment, assume that ' +
+        'type can be imported from this path.',
+    )
+
     .describe('noHeader', 'Do not write header')
 
     .demand('o')
@@ -80,7 +87,8 @@ let argv: SchematsConfig = yargs
             {
                 camelCase: argv.camelCase,
                 writeHeader: !argv.noHeader,
-                datesAsStrings: argv.datesAsStrings
+                datesAsStrings: argv.datesAsStrings,
+                jsonTypesFile: argv.jsonTypesFile,
             }
         )
         fs.writeFileSync(argv.output, formattedOutput)

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,13 +11,15 @@ export type OptionValues = {
     /** Leave date, timestamp, and timestamptz columns as strings, rather than Dates. */
     datesAsStrings?: boolean;
     writeHeader?: boolean // write schemats description header
+    /** Import types for jsdoc-tagged JSON columns from this path */
+    jsonTypesFile?: string;
 }
 
 export default class Options {
     public options: OptionValues
 
     constructor (options: OptionValues = {}) {
-        this.options = {...DEFAULT_OPTIONS, ...options}
+        this.options = { ...DEFAULT_OPTIONS, ...options }
     }
 
     transformTypeName (typename: string) {


### PR DESCRIPTION
Adds `--jsonTypesFile` flag, which links `@type {Type}` JSDoc comments on `json` columns to a TypeScript type defined in that file.