### PR TITLE
Attach type references to runtime objects

### DIFF
--- a/src/__tests__/typescript.test.ts
+++ b/src/__tests__/typescript.test.ts
@@ -17,22 +17,24 @@ describe('TypeScript', () => {
         schemaName,
         options,
       );
-      expect(tableInterface).toEqual(
-        `
-      // Table tableName
-       export interface TableName {
-        }
-       export interface TableNameInput {
-        }
-      const tableName = {
-        tableName: 'tableName',
-        columns: [],
-        requiredForInsert: [],
-        primaryKey: null,
-        foreignKeys: {},
-      } as const;
-  `,
-      );
+      expect(tableInterface).toMatchInlineSnapshot(`
+        "
+              // Table tableName
+               export interface TableName {
+                }
+               export interface TableNameInput {
+                }
+              const tableName = {
+                tableName: 'tableName',
+                columns: [],
+                requiredForInsert: [],
+                primaryKey: null,
+                foreignKeys: {},
+                $type: null as unknown as TableName,
+                $input: null as unknown as TableNameInput
+              } as const;
+          "
+      `);
       expect(types).toEqual(new Set());
       expect(names).toMatchInlineSnapshot(`
         Object {
@@ -55,22 +57,24 @@ describe('TypeScript', () => {
           prefixWithSchemaNames: true,
         }),
       );
-      expect(tableInterface).toEqual(
-        `
-      // Table testschemaname.table_name
-       export interface TestschemanameTableName {
-        }
-       export interface TestschemanameTableNameInput {
-        }
-      const testschemaname_table_name = {
-        tableName: 'testschemaname.table_name',
-        columns: [],
-        requiredForInsert: [],
-        primaryKey: null,
-        foreignKeys: {},
-      } as const;
-  `,
-      );
+      expect(tableInterface).toMatchInlineSnapshot(`
+        "
+              // Table testschemaname.table_name
+               export interface TestschemanameTableName {
+                }
+               export interface TestschemanameTableNameInput {
+                }
+              const testschemaname_table_name = {
+                tableName: 'testschemaname.table_name',
+                columns: [],
+                requiredForInsert: [],
+                primaryKey: null,
+                foreignKeys: {},
+                $type: null as unknown as TestschemanameTableName,
+                $input: null as unknown as TestschemanameTableNameInput
+              } as const;
+          "
+      `);
       expect(types).toEqual(new Set());
       expect(names).toMatchInlineSnapshot(`
         Object {
@@ -91,22 +95,24 @@ describe('TypeScript', () => {
         schemaName,
         options,
       );
-      expect(tableInterface).toEqual(
-        `
-      // Table package
-       export interface Package {
-        }
-       export interface PackageInput {
-        }
-      const package_ = {
-        tableName: 'package',
-        columns: [],
-        requiredForInsert: [],
-        primaryKey: null,
-        foreignKeys: {},
-      } as const;
-  `,
-      );
+      expect(tableInterface).toMatchInlineSnapshot(`
+        "
+              // Table package
+               export interface Package {
+                }
+               export interface PackageInput {
+                }
+              const package_ = {
+                tableName: 'package',
+                columns: [],
+                requiredForInsert: [],
+                primaryKey: null,
+                foreignKeys: {},
+                $type: null as unknown as Package,
+                $input: null as unknown as PackageInput
+              } as const;
+          "
+      `);
       expect(types).toEqual(new Set());
       expect(names).toMatchInlineSnapshot(`
         Object {
@@ -140,27 +146,28 @@ describe('TypeScript', () => {
         schemaName,
         options,
       );
-      // TODO(danvk): fix spacing in output
-      expect(tableInterface).toEqual(
-        `
-      // Table tableName
-       export interface TableName {
-        col1: string;
-col2: boolean;
-}
-       export interface TableNameInput {
-        col1: string;
-col2: boolean;
-}
-      const tableName = {
-        tableName: 'tableName',
-        columns: ['col1', 'col2'],
-        requiredForInsert: ['col1', 'col2'],
-        primaryKey: null,
-        foreignKeys: {},
-      } as const;
-  `,
-      );
+      expect(tableInterface).toMatchInlineSnapshot(`
+        "
+              // Table tableName
+               export interface TableName {
+                col1: string;
+        col2: boolean;
+        }
+               export interface TableNameInput {
+                col1: string;
+        col2: boolean;
+        }
+              const tableName = {
+                tableName: 'tableName',
+                columns: ['col1', 'col2'],
+                requiredForInsert: ['col1', 'col2'],
+                primaryKey: null,
+                foreignKeys: {},
+                $type: null as unknown as TableName,
+                $input: null as unknown as TableNameInput
+              } as const;
+          "
+      `);
       expect(names).toMatchInlineSnapshot(`
         Object {
           "input": "TableNameInput",
@@ -202,28 +209,30 @@ col2: boolean;
       );
 
       // None of the reserved word columns need to be quoted.
-      expect(tableInterface).toEqual(
-        `
-      // Table tableName
-       export interface TableName {
-        string: string;
-number: number;
-package: boolean;
-}
-       export interface TableNameInput {
-        string: string;
-number: number;
-package: boolean;
-}
-      const tableName = {
-        tableName: 'tableName',
-        columns: ['string', 'number', 'package'],
-        requiredForInsert: ['string', 'number', 'package'],
-        primaryKey: null,
-        foreignKeys: {},
-      } as const;
-  `,
-      );
+      expect(tableInterface).toMatchInlineSnapshot(`
+        "
+              // Table tableName
+               export interface TableName {
+                string: string;
+        number: number;
+        package: boolean;
+        }
+               export interface TableNameInput {
+                string: string;
+        number: number;
+        package: boolean;
+        }
+              const tableName = {
+                tableName: 'tableName',
+                columns: ['string', 'number', 'package'],
+                requiredForInsert: ['string', 'number', 'package'],
+                primaryKey: null,
+                foreignKeys: {},
+                $type: null as unknown as TableName,
+                $input: null as unknown as TableNameInput
+              } as const;
+          "
+      `);
       expect(names).toMatchInlineSnapshot(`
         Object {
           "input": "TableNameInput",

--- a/src/__tests__/typescript.test.ts
+++ b/src/__tests__/typescript.test.ts
@@ -330,4 +330,57 @@ describe('TypeScript', () => {
       );
     });
   });
+
+  describe.only('attachJoinTypes', () => {
+    const tsCode = `
+    const table_with_foreign_key = {
+      tableName: 'table_with_foreign_key',
+      columns: ['id', 'user_id', 'sentiment'],
+      requiredForInsert: ['id', 'user_id', 'sentiment'],
+      primaryKey: 'id',
+      foreignKeys: {user_id: { table: 'other_table', column: 'id', $type: null as unknown /* other_table */ },},
+      $type: null as unknown as TableWithForeignKey,
+      $input: null as unknown as TableWithForeignKeyInput
+    } as const;
+    `;
+    it('should attach joined types to generated TypeScript output', () => {
+      expect(
+        TypeScript.attachJoinTypes(tsCode, {
+          other_table: {
+            var: 'other_table',
+            type: 'OtherTable',
+            input: 'OtherTableInput',
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        "
+            const table_with_foreign_key = {
+              tableName: 'table_with_foreign_key',
+              columns: ['id', 'user_id', 'sentiment'],
+              requiredForInsert: ['id', 'user_id', 'sentiment'],
+              primaryKey: 'id',
+              foreignKeys: {user_id: { table: 'other_table', column: 'id', $type: null as unknown /* other_table */ },},
+              $type: null as unknown as TableWithForeignKey,
+              $input: null as unknown as TableWithForeignKeyInput
+            } as const;
+            "
+      `);
+    });
+
+    it('should leave unmatched types alone', () => {
+      expect(TypeScript.attachJoinTypes(tsCode, {})).toMatchInlineSnapshot(`
+        "
+            const table_with_foreign_key = {
+              tableName: 'table_with_foreign_key',
+              columns: ['id', 'user_id', 'sentiment'],
+              requiredForInsert: ['id', 'user_id', 'sentiment'],
+              primaryKey: 'id',
+              foreignKeys: {user_id: { table: 'other_table', column: 'id', $type: null as unknown /* other_table */ },},
+              $type: null as unknown as TableWithForeignKey,
+              $input: null as unknown as TableWithForeignKeyInput
+            } as const;
+            "
+      `);
+    });
+  });
 });

--- a/src/__tests__/typescript.test.ts
+++ b/src/__tests__/typescript.test.ts
@@ -331,7 +331,7 @@ describe('TypeScript', () => {
     });
   });
 
-  describe.only('attachJoinTypes', () => {
+  describe('attachJoinTypes', () => {
     const tsCode = `
     const table_with_foreign_key = {
       tableName: 'table_with_foreign_key',
@@ -359,7 +359,7 @@ describe('TypeScript', () => {
               columns: ['id', 'user_id', 'sentiment'],
               requiredForInsert: ['id', 'user_id', 'sentiment'],
               primaryKey: 'id',
-              foreignKeys: {user_id: { table: 'other_table', column: 'id', $type: null as unknown /* other_table */ },},
+              foreignKeys: {user_id: { table: 'other_table', column: 'id', $type: null as unknown as OtherTable },},
               $type: null as unknown as TableWithForeignKey,
               $input: null as unknown as TableWithForeignKeyInput
             } as const;

--- a/src/__tests__/typescript.test.ts
+++ b/src/__tests__/typescript.test.ts
@@ -242,6 +242,73 @@ describe('TypeScript', () => {
       `);
       expect(types).toEqual(new Set());
     });
+
+    it('table with foreign key', () => {
+      const [tableInterface, names, types] = TypeScript.generateTableInterface(
+        'table_with_foreign_key',
+        {
+          columns: {
+            id: {
+              udtName: 'varchar',
+              tsType: 'string',
+              nullable: false,
+              hasDefault: false,
+            },
+            user_id: {
+              udtName: 'char',
+              tsType: 'string',
+              nullable: false,
+              hasDefault: false,
+              foreignKey: {
+                table: 'other_table',
+                column: 'id',
+              },
+            },
+            sentiment: {
+              udtName: 'char',
+              tsType: 'string',
+              nullable: false,
+              hasDefault: false,
+            },
+          },
+          primaryKey: 'id',
+        },
+        schemaName,
+        options,
+      );
+      expect(tableInterface).toMatchInlineSnapshot(`
+        "
+              // Table table_with_foreign_key
+               export interface TableWithForeignKey {
+                id: string;
+        user_id: string;
+        sentiment: string;
+        }
+               export interface TableWithForeignKeyInput {
+                id: string;
+        user_id: string;
+        sentiment: string;
+        }
+              const table_with_foreign_key = {
+                tableName: 'table_with_foreign_key',
+                columns: ['id', 'user_id', 'sentiment'],
+                requiredForInsert: ['id', 'user_id', 'sentiment'],
+                primaryKey: 'id',
+                foreignKeys: {user_id: { table: 'other_table', column: 'id', $type: null as unknown /* other_table */ },},
+                $type: null as unknown as TableWithForeignKey,
+                $input: null as unknown as TableWithForeignKeyInput
+              } as const;
+          "
+      `);
+      expect(names).toMatchInlineSnapshot(`
+        Object {
+          "input": "TableWithForeignKeyInput",
+          "type": "TableWithForeignKey",
+          "var": "table_with_foreign_key",
+        }
+      `);
+      expect(types).toEqual(new Set());
+    });
   });
 
   describe('generateEnumType', () => {

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -70,6 +70,9 @@ export function attachJoinTypes(
     /(\$type: null as unknown) \/\* ([^*]+) \*\//,
     (match, g1, tableName) => {
       const names = tableToNames[tableName];
+      if (!names) {
+        console.warn('Lookup for', tableName, 'failed in', tableToNames);
+      }
       return names ? g1 + ' as ' + names.type : match;
     },
   );

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -67,10 +67,10 @@ export function attachJoinTypes(
   tableToNames: Record<string, TableNames>,
 ): string {
   return tableTs.replace(
-    /(\$type: null as unknown) \/* ([^*]+) \*\//,
-    (_match, g1, tableName) => {
+    /(\$type: null as unknown) \/\* ([^*]+) \*\//,
+    (match, g1, tableName) => {
       const names = tableToNames[tableName];
-      return names ? g1 + ' as ' + names.type : g1;
+      return names ? g1 + ' as ' + names.type : match;
     },
   );
 }

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -19,7 +19,7 @@ function nameIsReservedKeyword(name: string): boolean {
  * Returns a version of the name that can be used as a symbol name, e.g.
  * 'number' --> 'number_'.
  */
-export function getSafeSymbolName(name: string): string {
+function getSafeSymbolName(name: string): string {
   if (nameIsReservedKeyword(name)) {
     return name + '_';
   } else {
@@ -28,28 +28,25 @@ export function getSafeSymbolName(name: string): string {
 }
 
 /** Converts snake_case --> CamelCase */
-export function toCamelCase(name: string) {
+function toCamelCase(name: string) {
   return name
     .split('_')
     .map(word => (word ? word[0].toUpperCase() + word.slice(1) : ''))
     .join('');
 }
 
-export function quotedArray(xs: string[]) {
+function quotedArray(xs: string[]) {
   return '[' + xs.map(x => `'${x}'`).join(', ') + ']';
 }
 
-export function quoteNullable(x: string | null | undefined) {
+function quoteNullable(x: string | null | undefined) {
   return x === null || x === undefined ? 'null' : `'${x}'`;
 }
 
-export function quoteForeignKeyMap(x: {
-  [columnName: string]: ForeignKey;
-}): string {
-  const colsTs = _.map(
-    x,
-    (v, k) => `${k}: { table: '${v.table}', column: '${v.column}' },`,
-  );
+function quoteForeignKeyMap(x: {[columnName: string]: ForeignKey}): string {
+  const colsTs = _.map(x, (v, k) => {
+    return `${k}: { table: '${v.table}', column: '${v.column}', $type: null as unknown /* ${v.table} */ },`;
+  });
   return '{' + colsTs.join('\n  ') + '}';
 }
 
@@ -63,6 +60,19 @@ export interface TableNames {
   var: string;
   type: string;
   input: string;
+}
+
+export function attachJoinTypes(
+  tableTs: string,
+  tableToNames: Record<string, TableNames>,
+): string {
+  return tableTs.replace(
+    /(\$type: null as unknown) \/* ([^*]+) \*\//,
+    (_match, g1, tableName) => {
+      const names = tableToNames[tableName];
+      return names ? g1 + ' as ' + names.type : g1;
+    },
+  );
 }
 
 /** Returns [Table TypeScript, output variable name, set of TS types to import] */
@@ -141,6 +151,8 @@ export function generateTableInterface(
         requiredForInsert: ${quotedArray(requiredForInsert)},
         primaryKey: ${quoteNullable(primaryKey)},
         foreignKeys: ${quoteForeignKeyMap(foreignKeys)},
+        $type: null as unknown as ${names.type},
+        $input: null as unknown as ${names.input}
       } as const;
   `,
     names,

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -62,6 +62,11 @@ export interface TableNames {
   input: string;
 }
 
+/**
+ * generateTableInterface() leaves some references to be filled in later, when a more complete
+ * picture of the schema is available. This fills those references in:
+ * 'null as unknown /* users *\/' --> 'null as unknown as Users'.
+ */
 export function attachJoinTypes(
   tableTs: string,
   tableToNames: Record<string, TableNames>,

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -67,12 +67,9 @@ export function attachJoinTypes(
   tableToNames: Record<string, TableNames>,
 ): string {
   return tableTs.replace(
-    /(\$type: null as unknown) \/\* ([^*]+) \*\//,
+    /(\$type: null as unknown) \/\* ([^*]+) \*\//g,
     (match, g1, tableName) => {
       const names = tableToNames[tableName];
-      if (!names) {
-        console.warn('Lookup for', tableName, 'failed in', tableToNames);
-      }
       return names ? g1 + ' as ' + names.type : match;
     },
   );

--- a/test/integration/__snapshots__/integration.test.ts.snap
+++ b/test/integration/__snapshots__/integration.test.ts.snap
@@ -366,7 +366,7 @@ const comment = {
   primaryKey: 'id',
   foreignKeys: {
     doc_id: { table: 'doc', column: 'id', $type: null as unknown as Doc },
-    author_id: { table: 'users', column: 'id', $type: null as unknown /* users */ },
+    author_id: { table: 'users', column: 'id', $type: null as unknown as Users },
   },
   $type: null as unknown as Comment,
   $input: null as unknown as CommentInput
@@ -508,7 +508,7 @@ const public_comment = {
   primaryKey: 'id',
   foreignKeys: {
     doc_id: { table: 'doc', column: 'id', $type: null as unknown as PublicDoc },
-    author_id: { table: 'users', column: 'id', $type: null as unknown /* users */ },
+    author_id: { table: 'users', column: 'id', $type: null as unknown as PublicUsers },
   },
   $type: null as unknown as PublicComment,
   $input: null as unknown as PublicCommentInput

--- a/test/integration/__snapshots__/integration.test.ts.snap
+++ b/test/integration/__snapshots__/integration.test.ts.snap
@@ -142,6 +142,8 @@ const users = {
   requiredForInsert: ['email', 'id', 'pass_crypt', 'creation_time'],
   primaryKey: null,
   foreignKeys: {},
+  $type: null as unknown as Users,
+  $input: null as unknown as UsersInput
 } as const;
 
 
@@ -300,6 +302,8 @@ const users = {
   requiredForInsert: ['email', 'id', 'passCrypt', 'creationTime'],
   primaryKey: null,
   foreignKeys: {},
+  $type: null as unknown as Users,
+  $input: null as unknown as UsersInput
 } as const;
 
 
@@ -361,9 +365,11 @@ const comment = {
   requiredForInsert: ['doc_id', 'author_id', 'content_md'],
   primaryKey: 'id',
   foreignKeys: {
-    doc_id: { table: 'doc', column: 'id' },
-    author_id: { table: 'users', column: 'id' },
+    doc_id: { table: 'doc', column: 'id', $type: null as unknown as Doc },
+    author_id: { table: 'users', column: 'id', $type: null as unknown /* users */ },
   },
+  $type: null as unknown as Comment,
+  $input: null as unknown as CommentInput
 } as const;
 
 // Table doc
@@ -384,7 +390,9 @@ const doc = {
   columns: ['id', 'created_by', 'title', 'contents'],
   requiredForInsert: ['created_by'],
   primaryKey: 'id',
-  foreignKeys: { created_by: { table: 'users', column: 'id' }, },
+  foreignKeys: { created_by: { table: 'users', column: 'id', $type: null as unknown as Users }, },
+  $type: null as unknown as Doc,
+  $input: null as unknown as DocInput
 } as const;
 
 // Table table_with_underscores
@@ -400,6 +408,8 @@ const table_with_underscores = {
   requiredForInsert: ['column_with_underscores'],
   primaryKey: null,
   foreignKeys: {},
+  $type: null as unknown as TableWithUnderscores,
+  $input: null as unknown as TableWithUnderscoresInput
 } as const;
 
 // Table users
@@ -419,6 +429,8 @@ const users = {
   requiredForInsert: ['name'],
   primaryKey: 'id',
   foreignKeys: {},
+  $type: null as unknown as Users,
+  $input: null as unknown as UsersInput
 } as const;
 
 
@@ -495,9 +507,11 @@ const public_comment = {
   requiredForInsert: ['docId', 'authorId', 'contentMd'],
   primaryKey: 'id',
   foreignKeys: {
-    doc_id: { table: 'doc', column: 'id' },
-    author_id: { table: 'users', column: 'id' },
+    doc_id: { table: 'doc', column: 'id', $type: null as unknown as PublicDoc },
+    author_id: { table: 'users', column: 'id', $type: null as unknown /* users */ },
   },
+  $type: null as unknown as PublicComment,
+  $input: null as unknown as PublicCommentInput
 } as const;
 
 // Table public.doc
@@ -518,7 +532,9 @@ const public_doc = {
   columns: ['id', 'createdBy', 'title', 'contents'],
   requiredForInsert: ['createdBy'],
   primaryKey: 'id',
-  foreignKeys: { created_by: { table: 'users', column: 'id' }, },
+  foreignKeys: { created_by: { table: 'users', column: 'id', $type: null as unknown as PublicUsers }, },
+  $type: null as unknown as PublicDoc,
+  $input: null as unknown as PublicDocInput
 } as const;
 
 // Table public.table_with_underscores
@@ -534,6 +550,8 @@ const public_table_with_underscores = {
   requiredForInsert: ['columnWithUnderscores'],
   primaryKey: null,
   foreignKeys: {},
+  $type: null as unknown as PublicTableWithUnderscores,
+  $input: null as unknown as PublicTableWithUnderscoresInput
 } as const;
 
 // Table public.users
@@ -553,6 +571,8 @@ const public_users = {
   requiredForInsert: ['name'],
   primaryKey: 'id',
   foreignKeys: {},
+  $type: null as unknown as PublicUsers,
+  $input: null as unknown as PublicUsersInput
 } as const;
 
 
@@ -609,6 +629,8 @@ const public_users = {
   requiredForInsert: ['name'],
   primaryKey: 'id',
   foreignKeys: {},
+  $type: null as unknown as PublicUsers,
+  $input: null as unknown as PublicUsersInput
 } as const;
 
 // Table public.table_with_underscores
@@ -624,6 +646,8 @@ const public_table_with_underscores = {
   requiredForInsert: ['column_with_underscores'],
   primaryKey: null,
   foreignKeys: {},
+  $type: null as unknown as PublicTableWithUnderscores,
+  $input: null as unknown as PublicTableWithUnderscoresInput
 } as const;
 
 

--- a/test/integration/schema-generation-test.ts
+++ b/test/integration/schema-generation-test.ts
@@ -46,7 +46,7 @@ export const schemaGenerationTest = () => {
     expect(await getGeneratedTs(inputSQLFile, config, db)).toMatchSnapshot();
   });
 
-  it('pg-to-sql with camelCase', async () => {
+  it.only('pg-to-sql with camelCase', async () => {
     const inputSQLFile = 'test/fixture/pg-to-ts.sql';
     const config = './test/fixture/pg-to-ts-camel.json';
     expect(await getGeneratedTs(inputSQLFile, config, db)).toMatchSnapshot();

--- a/test/integration/schema-generation-test.ts
+++ b/test/integration/schema-generation-test.ts
@@ -46,7 +46,7 @@ export const schemaGenerationTest = () => {
     expect(await getGeneratedTs(inputSQLFile, config, db)).toMatchSnapshot();
   });
 
-  it.only('pg-to-sql with camelCase', async () => {
+  it('pg-to-sql with camelCase', async () => {
     const inputSQLFile = 'test/fixture/pg-to-ts.sql';
     const config = './test/fixture/pg-to-ts-camel.json';
     expect(await getGeneratedTs(inputSQLFile, config, db)).toMatchSnapshot();


### PR DESCRIPTION
This attaches `$type` and `$input` references to the runtime table objects and foreign keys. This greatly facilitates type discovery for libraries.

Here's an example of what it looks like:

```ts
// Table doc
export interface Doc {
  id: string;
  created_by: string;
  title: string | null;
  contents: string | null;
}
export interface DocInput { /* ... */ }
const doc = {
  tableName: 'doc',
  columns: ['id', 'created_by', 'title', 'contents'],
  requiredForInsert: ['created_by'],
  primaryKey: 'id',
  foreignKeys: { created_by: { table: 'users', column: 'id', $type: null as unknown as Users } },
  $type: null as unknown as Doc,
  $input: null as unknown as DocInput
} as const;
```

The nice thing about this approach is that, if your library is passed the `doc` object (or the `tables` object), then it can figure out all the types for the tables and the joins from that object alone. No need to pass types in separately.