### PR TITLE
support bytea to buffer

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -4,6 +4,7 @@ const DEFAULT_OPTIONS: OptionValues = {
   writeHeader: true,
   camelCase: false,
   datesAsStrings: false,
+  byteasAsBuffers: false,
   prefixWithSchemaNames: false,
 };
 
@@ -11,6 +12,8 @@ export type OptionValues = {
   camelCase?: boolean;
   /** Leave date, timestamp, and timestamptz columns as strings, rather than Dates. */
   datesAsStrings?: boolean;
+  /** Leave bytea as Buffers, rather than strings. */
+  byteasAsBuffers?: boolean;
   writeHeader?: boolean; // write schemats description header
   /** Import types for jsdoc-tagged JSON columns from this path */
   jsonTypesFile?: string;

--- a/src/schemaPostgres.ts
+++ b/src/schemaPostgres.ts
@@ -23,13 +23,14 @@ export function pgTypeToTsType(
     case 'text':
     case 'citext':
     case 'uuid':
-    case 'bytea':
     case 'inet':
     case 'time':
     case 'timetz':
     case 'interval':
     case 'name':
       return 'string';
+    case 'bytea':
+      return options.options.byteasAsBuffers ? 'Buffer' : 'string';
     case 'int2':
     case 'int4':
     case 'int8':
@@ -62,8 +63,9 @@ export function pgTypeToTsType(
     case '_text':
     case '_citext':
     case '_uuid':
-    case '_bytea':
       return 'string[]';
+    case '_bytea':
+      return options.options.byteasAsBuffers ? 'Buffer[]' : 'string[]';
     case '_json':
     case '_jsonb':
       return 'Json[]';


### PR DESCRIPTION
Type `bytea` can transfer to `Buffer` if option is set.