### PR TITLE
Support specifying the type of all columns

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -103,7 +103,7 @@ export function generateTableInterface(
       jsdoc = comment ? `/** ${comment} */\n` : '';
 
     let {tsType} = columnDef;
-    if (tsType === 'Json' && options.options.jsonTypesFile && comment) {
+    if (options.options.jsonTypesFile && comment) {
       const m = JSDOC_TYPE_RE.exec(comment);
       if (m) {
         tsType = m[1].trim();

--- a/test/fixture/pg-to-ts.sql
+++ b/test/fixture/pg-to-ts.sql
@@ -43,5 +43,8 @@ COMMENT ON COLUMN comment.metadata IS 'Additional comment info @type {CommentMet
 COMMENT ON COLUMN comment.statuses IS 'List of statuses; Just an array for testing!';
 
 CREATE TABLE IF NOT EXISTS table_with_underscores (
+  id text not null PRIMARY KEY,
   column_with_underscores text not null
 );
+
+COMMENT ON COLUMN table_with_underscores.id IS 'Table ID has @type {TableId}';

--- a/test/integration/__snapshots__/integration.test.ts.snap
+++ b/test/integration/__snapshots__/integration.test.ts.snap
@@ -324,7 +324,7 @@ exports[`Integration tests Schema generation pg-to-sql features 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
 
-import { CommentMetadata } from \\"./pg-to-ts-json-types\\";
+import { CommentMetadata, TableId } from \\"./pg-to-ts-json-types\\";
 
 
 export type Json = unknown;
@@ -397,16 +397,20 @@ const doc = {
 
 // Table table_with_underscores
 export interface TableWithUnderscores {
+  /** Table ID has @type {TableId} */
+  id: TableId;
   column_with_underscores: string;
 }
 export interface TableWithUnderscoresInput {
+  /** Table ID has @type {TableId} */
+  id: TableId;
   column_with_underscores: string;
 }
 const table_with_underscores = {
   tableName: 'table_with_underscores',
-  columns: ['column_with_underscores'],
-  requiredForInsert: ['column_with_underscores'],
-  primaryKey: null,
+  columns: ['id', 'column_with_underscores'],
+  requiredForInsert: ['id', 'column_with_underscores'],
+  primaryKey: 'id',
   foreignKeys: {},
   $type: null as unknown as TableWithUnderscores,
   $input: null as unknown as TableWithUnderscoresInput
@@ -466,7 +470,7 @@ exports[`Integration tests Schema generation pg-to-sql with camelCase 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
 
-import { CommentMetadata } from \\"./pg-to-ts-json-types\\";
+import { CommentMetadata, TableId } from \\"./pg-to-ts-json-types\\";
 
 
 export type Json = unknown;
@@ -539,16 +543,20 @@ const public_doc = {
 
 // Table public.table_with_underscores
 export interface PublicTableWithUnderscores {
+  /** Table ID has @type {TableId} */
+  id: TableId;
   columnWithUnderscores: string;
 }
 export interface PublicTableWithUnderscoresInput {
+  /** Table ID has @type {TableId} */
+  id: TableId;
   columnWithUnderscores: string;
 }
 const public_table_with_underscores = {
   tableName: 'public.table_with_underscores',
-  columns: ['columnWithUnderscores'],
-  requiredForInsert: ['columnWithUnderscores'],
-  primaryKey: null,
+  columns: ['id', 'columnWithUnderscores'],
+  requiredForInsert: ['id', 'columnWithUnderscores'],
+  primaryKey: 'id',
   foreignKeys: {},
   $type: null as unknown as PublicTableWithUnderscores,
   $input: null as unknown as PublicTableWithUnderscoresInput
@@ -635,16 +643,20 @@ const public_users = {
 
 // Table public.table_with_underscores
 export interface PublicTableWithUnderscores {
+  /** Table ID has @type {TableId} */
+  id: string;
   column_with_underscores: string;
 }
 export interface PublicTableWithUnderscoresInput {
+  /** Table ID has @type {TableId} */
+  id: string;
   column_with_underscores: string;
 }
 const public_table_with_underscores = {
   tableName: 'public.table_with_underscores',
-  columns: ['column_with_underscores'],
-  requiredForInsert: ['column_with_underscores'],
-  primaryKey: null,
+  columns: ['id', 'column_with_underscores'],
+  requiredForInsert: ['id', 'column_with_underscores'],
+  primaryKey: 'id',
   foreignKeys: {},
   $type: null as unknown as PublicTableWithUnderscores,
   $input: null as unknown as PublicTableWithUnderscoresInput


### PR DESCRIPTION
It would be useful to use the `@Type` JsDoc annotation on more column types than just `json` and `jsonb`. For instance when using template literal type for entity identifiers.

This PR removes the `'Json'` boolean check, opening the door to specifying the type of any column.